### PR TITLE
fix: Allow OS to choose Python version

### DIFF
--- a/bin/prom433
+++ b/bin/prom433
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
 # prom433
 # Copyright (C) 2021 Andrew Wilkinson
 #


### PR DESCRIPTION
Specify simply "python3", which will typically be a symlink to the minor version selected on the platform.