### PR TITLE
feat: add --quiet to suppress server logging

### DIFF
--- a/prom433/arguments.py
+++ b/prom433/arguments.py
@@ -20,6 +20,8 @@ import os
 parser = argparse.ArgumentParser(
     description='Listens to messages from rtl_433 and exposes them '
     + 'as prometheus metrics')
+parser.add_argument('-q', '--quiet', action="store_true",
+                    help="don't log HTTP requests")
 parser.add_argument('--bind', type=str, nargs='?', default="0.0.0.0:9100",
                     help='the ip address and port to bind to')
 parser.add_argument('--mqtt', type=str, nargs='?', default="mqtt",

--- a/prom433/server.py
+++ b/prom433/server.py
@@ -21,6 +21,12 @@ from .prometheus import get_metrics
 
 
 class Handler(http.server.BaseHTTPRequestHandler):
+    def __init__(self, quiet=False):
+        self.quiet = quiet
+
+    def __call__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     def do_GET(self):
         if self.path == "/":
             self.send_index()
@@ -46,7 +52,15 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(get_metrics().encode("utf8"))
 
+    def log_request(self, code='-', size='-'):
+        if self.quiet:
+            return
+        else:
+            self.log_message('"%s" %s %s',
+                             self.requestline, str(code), str(size))
+
 
 def serve(args):  # pragma: no cover
-    server = http.server.HTTPServer(args.bind, Handler)
+    handler = Handler(args.quiet)
+    server = http.server.HTTPServer(args.bind, handler)
     server.serve_forever()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,6 +41,7 @@ class MockHandler(Handler):
         self.client_address = ("127.0.0.1", 8000)
         self.request_version = "1.0"
         self.command = "GET"
+        self.quiet = False
 
 
 class TestServer(unittest.TestCase):


### PR DESCRIPTION
Suppress server logging of all requests to limit noise in long running system logs. Method taken from here,
https://stackoverflow.com/questions/21631799/how-can-i-pass-parameters-to-a-requesthandler