### PR TITLE
chore: example systemd unit and environment files

### DIFF
--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,15 @@
+# Systemd files readme
+
+This directory contains an example systemd unit file, and configuration environment file.
+
+## prom433.service
+This is the systemd unit file for managing the prom433 service. It may need to be modified for your environment.  See comments in the file.  It assumes that you have created a "prom433" user and group.  You can create these with the following commands if they do not exist on your system (e.g. if installed manually).
+
+```
+groupadd -r prom433
+useradd -r -g prom433 -s /sbin/nologin -c "prom433 user" prom433
+```
+
+## prom433.example
+This is an example of a configuration file you can use as a basis for `/etc/sysconfig/prom433` to control the options passed to the prom433 binary.
+This file is only required if you don't want to use the defaults specified in the above systemd unit file. You must remove the `.example` suffix when placing it in the `/etc/sysconfig` directory.

--- a/systemd/prom433.example
+++ b/systemd/prom433.example
@@ -1,0 +1,3 @@
+QUIET="--quiet"
+MQTT_HOST="localhost"
+BIND_HOST_PORT="localhost:9100"

--- a/systemd/prom433.service
+++ b/systemd/prom433.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=Prom433 - Publish Prometheus metrics from rtl_433 SDR receiver
+Documentation=https://github.com/andrewjw/prom433
+# Replace with different MQTT broker as needed
+After=mosquitto.service
+
+[Service]
+# useradd -r -g prom433 -s /sbin/nologin -c "prom433 user" prom433
+User=prom433
+# groupadd -r prom433
+Group=prom433
+
+# Set defaults. Overwritten by /etc/sysconfig file if present
+Environment=QUIET=""
+Environment=MQTT_HOST="localhost"
+Environment=BIND_HOST_PORT="localhost:9100"
+Environment=DROP_AFTER=0
+EnvironmentFile=-/etc/sysconfig/prom433
+
+Type=simple
+Restart=on-failure
+TimeoutStopSec=10
+ExecStart=/usr/local/bin/prom433 $QUIET --mqtt ${MQTT_HOST} --bind ${BIND_HOST_PORT} --drop-after ${DROP_AFTER}
+
+# Security sandbox features
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
+LimitNOFILE=1000
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+UMask=0077
+
+# Modify as needed if service not on localhost
+IPAddressDeny=any
+IPAddressAllow=localhost
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
* add prom433.service unit file to support management with systemd
* add prom433.example for use in /etc/sysconfig to set service options