### PR TITLE
Add time parser

### DIFF
--- a/prom433/prometheus.py
+++ b/prom433/prometheus.py
@@ -15,6 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime, timezone
+import dateutil.parser
+import dateutil.tz
+import dateutil.utils
 import json
 import logging
 
@@ -96,8 +99,8 @@ METRICS_PREFIXES = {
 
 METRICS_CONVERT = {
     "prom433_radio_clock":
-        lambda x: datetime.strptime(x, "%Y-%m-%dT%H:%M:%S")
-        .replace(tzinfo=timezone.utc).timestamp()
+        lambda x: dateutil.utils.default_tzinfo(dateutil.parser.parse(x),
+        dateutil.tz.tzoffset("UTC", 0)).timestamp()
 }
 
 TAG_KEYS = {"id", "channel", "model"}
@@ -146,8 +149,10 @@ def prometheus(message, drop_after):
 
     for key, value in payload.items():
         if key == "time":
-            time_value = datetime.strptime(payload[key], "%Y-%m-%d %H:%M:%S") \
-                        .timestamp()
+            if ':' in payload[key]:
+                time_value = dateutil.parser.parse(payload[key]).timestamp()
+            else:
+                time_value = datetime.fromtimestamp(float(payload[key])).timestamp()
         elif key in TAG_KEYS:
             tags[key] = value
         elif key in METRIC_NAME:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pycodestyle==2.10.0
 coveralls==3.3.1
 python-semantic-release==7.33.0
 paho-mqtt==1.6.1
+python-dateutil==2.8.1

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -23,6 +23,7 @@ from prom433.prometheus import METRICS
 
 MESSAGE_TEXT = open("tests/output_sample.txt", "rb").read().decode("utf8")
 DROP_TEXT = open("tests/dropmetric_sample.txt", "rb").read().decode("utf8")
+TIMESTAMP_TEXT = open("tests/timestamp_sample.txt", "rb").read().decode("utf8")
 
 
 def mock_popen(args, stdout):
@@ -84,3 +85,42 @@ class TestPrometheus(unittest.TestCase):
         # The Fineoffset hasn't been seen for an hour,
         # but dropping is disabled.
         self.assertIn("""Fineoffset-WHx080""", prom)
+
+    def test_timestamp(self):
+        for line in TIMESTAMP_TEXT.split("\n"):
+            prometheus(line, 0)
+
+        prom = get_metrics()
+
+        #report_meta time:utc:tz
+        self.assertIn(
+            """prom433_last_message{id="1", """ +
+            """model="LaCrosse-TX"} 1677374905.000000""", prom)
+        #report_meta time:tz
+        self.assertIn(
+            """prom433_last_message{id="2", """ +
+            """model="LaCrosse-TX"} 1677374905.000000""", prom)
+        #report_meta time:iso:tz
+        self.assertIn(
+            """prom433_last_message{id="3", """ +
+            """model="LaCrosse-TX"} 1677374905.000000""", prom)
+        #report_meta time:unix
+        self.assertIn(
+            """prom433_last_message{id="4", """ +
+            """model="LaCrosse-TX"} 1677374905.000000""", prom)
+        #report_meta time:utc:tz:usec
+        self.assertIn(
+            """prom433_last_message{id="101", """ +
+            """model="LaCrosse-TX31UIT"} 1677374905.538138""", prom)
+        #report_meta time:tz:usec
+        self.assertIn(
+            """prom433_last_message{id="102", """ +
+            """model="LaCrosse-TX31UIT"} 1677374905.538138""", prom)
+        #report_meta time:iso:tz:usec
+        self.assertIn(
+            """prom433_last_message{id="103", """ +
+            """model="LaCrosse-TX31UIT"} 1677374905.538138""", prom)
+        #report_meta time:unix:usec
+        self.assertIn(
+            """prom433_last_message{id="104", """ +
+            """model="LaCrosse-TX31UIT"} 1677374905.538138""", prom)

--- a/tests/timestamp_sample.txt
+++ b/tests/timestamp_sample.txt
@@ -1,0 +1,8 @@
+{"time" : "2023-02-26 01:28:25Z", "model" : "LaCrosse-TX", "id" : 1, "temperature_C" : 4.000, "mic" : "PARITY"}
+{"time" : "2023-02-25 17:28:25-0800", "model" : "LaCrosse-TX", "id" : 2, "temperature_C" : 4.000, "mic" : "PARITY"}
+{"time" : "2023-02-25T17:28:25-0800", "model" : "LaCrosse-TX", "id" : 3, "temperature_C" : 4.000, "mic" : "PARITY"}
+{"time" : "1677374905", "model" : "LaCrosse-TX", "id" : 4, "temperature_C" : 4.000, "mic" : "PARITY"}
+{"time" : "2023-02-26 01:28:25.538138Z", "model" : "LaCrosse-TX31UIT", "id" : 101, "temperature_C" : 4.000, "mic" : "PARITY"}
+{"time" : "2023-02-25 17:28:25.538138-0800", "model" : "LaCrosse-TX31UIT", "id" : 102, "temperature_C" : 4.000, "mic" : "PARITY"}
+{"time" : "2023-02-25T17:28:25.538138-0800", "model" : "LaCrosse-TX31UIT", "id" : 103, "temperature_C" : 4.000, "mic" : "PARITY"}
+{"time" : "1677374905.538138", "model" : "LaCrosse-TX31UIT", "id" : 104, "temperature_C" : 4.000, "mic" : "PARITY"}


### PR DESCRIPTION
This might need a little background...  When I first tried to use prom433, it threw errors when parsing my rtl_433 output.  I later figured out that prom433 did not like that I was using a timestamp format that include floating point seconds.  I was using the rtl_433 timestamp format of "time:usec", to get better resolution for each of my three weather stations.

This set of patches uses the python-dateutil module to implement a generic date/time parser that will handle all of the various time formats that rtl_433 can output.  I took the liberty of also modifying the timestamp conversion for the "radio_clock" field (that you had just fixed...), as I thought it would be good to use a consistent approach. 

I also created a set of test cases for each of rtl_433 timestamp formats.